### PR TITLE
Fix property definition for AOT compilation

### DIFF
--- a/src/trumbowyg.component.ts
+++ b/src/trumbowyg.component.ts
@@ -34,7 +34,7 @@ export class Trumbowyg implements OnInit, OnDestroy {
   }
   @Input() liveUpdate = false;
   @Input('update') update: Observable<any>;
-  @Output() private savedContent: EventEmitter<any> = new EventEmitter();
+  @Output() public savedContent: EventEmitter<any> = new EventEmitter();
 
   private loaded$: Observable<boolean>;
   private content$: Subject<string> = new BehaviorSubject("");


### PR DESCRIPTION
AOT requires properties that are to be accessed outside of the component to be public. I had an issue with `savedContent`, this fixes the issue.