### PR TITLE
Plugins support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,17 @@ import {LoadExternalFiles} from "./src/load-external-file.service";
 @NgModule({
   imports: [],
   declarations: [ Trumbowyg ],
-  providers: [ TrumbowygService, LoadExternalFiles ],
+  providers: [ LoadExternalFiles ],
   exports: [ Trumbowyg ]
 })
-export class TrumbowygModule {}
+
+export class TrumbowygModule {
+  forRoot(config: any) {
+    return {
+      NgModule: TrumbowygModule,
+      providers: [
+        { provide: TrumbowygService, useValue: config }
+      ]
+    };
+  }
+}

--- a/index.ts
+++ b/index.ts
@@ -1,21 +1,22 @@
-import { NgModule } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import {Trumbowyg} from "./src/trumbowyg.component";
 import {TrumbowygService} from "./src/trumbowyg.service";
+import {TrumbowygConfig} from "./src/trumbowyg.config";
 import {LoadExternalFiles} from "./src/load-external-file.service";
 
 @NgModule({
   imports: [],
   declarations: [ Trumbowyg ],
-  providers: [ LoadExternalFiles ],
+  providers: [ LoadExternalFiles, TrumbowygService ],
   exports: [ Trumbowyg ]
 })
 
 export class TrumbowygModule {
-  forRoot(config: any) {
+  static forRoot(config: TrumbowygConfig): ModuleWithProviders {
     return {
-      NgModule: TrumbowygModule,
+      ngModule: TrumbowygModule,
       providers: [
-        { provide: TrumbowygService, useValue: config }
+        { provide: TrumbowygConfig, useValue: config }
       ]
     };
   }

--- a/src/trumbowyg.config.ts
+++ b/src/trumbowyg.config.ts
@@ -1,0 +1,4 @@
+
+export class TrumbowygConfig {
+  plugins: string[];
+}

--- a/src/trumbowyg.service.ts
+++ b/src/trumbowyg.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from "@angular/core";
+import {Optional, Injectable} from "@angular/core";
 import {Observable} from "rxjs/Observable";
 import "rxjs/add/operator/publishReplay";
 import "rxjs/add/operator/switchMap";
@@ -9,6 +9,7 @@ import {LoadExternalFiles} from "./load-external-file.service";
 
 const JQUERY_SCRIPT_URL = 'https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js';
 const TRUMBOWYG_PREFIX_URL = 'https://cdnjs.cloudflare.com/ajax/libs/Trumbowyg/2.7.0';
+const TRUMBOWYG_PLUGINS_PREFIX = TRUMBOWYG_PREFIX_URL + '/plugins';
 const TRUMBOWYG_STYLES_URL = TRUMBOWYG_PREFIX_URL + '/ui/trumbowyg.min.css';
 const TRUMBOWYG_SCRIPT_URL = TRUMBOWYG_PREFIX_URL + '/trumbowyg.min.js';
 
@@ -20,16 +21,27 @@ export class TrumbowygService {
   private isLoaded$: Observable<boolean>;
   private loadedLangs: Array<string> = [];
 
-  constructor(private loadFiles: LoadExternalFiles) {
+  constructor(private loadFiles: LoadExternalFiles, @Optional() config: any) {
+    const pluginFiles = this.parsePlugins(config);
+    const trumbowygLoadPromise = loadFiles.load(
+      TRUMBOWYG_STYLES_URL, TRUMBOWYG_SCRIPT_URL, ...pluginFiles);
+
     const loadFiles$ = window && window["jQuery"] && window["jQuery"]().on ?
-      fromPromise(loadFiles.load(TRUMBOWYG_STYLES_URL, TRUMBOWYG_SCRIPT_URL))
+      fromPromise(trumbowygLoadPromise)
       : fromPromise(loadFiles.load(JQUERY_SCRIPT_URL))
-        .switchMap(() => fromPromise(loadFiles.load(TRUMBOWYG_STYLES_URL, TRUMBOWYG_SCRIPT_URL)));
+        .switchMap(() => fromPromise(trumbowygLoadPromise));
 
     this.isLoaded$ = loadFiles$
       .map(() => true)
       .publishReplay(1)
       .refCount();
+  }
+
+  private parsePlugins(config: any): string[] {
+    if (!config ||  !Array.isArray(config.plugins)) { return []; }
+
+    return config.plugins.map(
+      (plugin: string) => `${TRUMBOWYG_PLUGINS_PREFIX}/${plugin}/trumbowyg.${plugin}.min.js`);
   }
 
   private loadLang(lang: string): Observable<any> {


### PR DESCRIPTION
Added possibility to configure module with Trumbowyg plugins available in CDN. To add such plugin use `TrumbowygModule.forRoot` function:

```
@NgModule({
...
  imports: [
    TrumbowygModule.forRoot({ plugins: [ 'table' ]})
  ]
...
})
```

in root module.